### PR TITLE
Diff: add functions

### DIFF
--- a/Hit/Hit.hs
+++ b/Hit/Hit.hs
@@ -164,7 +164,7 @@ getLog revision git = do
           where author = commitAuthor commit
 
 showDiff rev1 rev2 git = do
-    diffList <- getDiff rev1 rev2 git
+    diffList <- getDiffFromRev rev1 rev2 git
     mapM_ showADiff diffList
     where
         showADiff :: HitDiff -> IO ()


### PR DESCRIPTION
sometime it's easier to get a diff from a ref and most of the time the diff is
performed between two references. So, it updated the getDiffWith to use Ref
instead of Revision. Added a function to get the Diff but from a revision.
