### PR TITLE
Do not analyze .git/branches directory when identifying git repo

### DIFF
--- a/Data/Git/Storage.hs
+++ b/Data/Git/Storage.hs
@@ -149,7 +149,7 @@ isRepo :: FilePath -> IO Bool
 isRepo path = do
     dir     <- isDirectory path
     subDirs <- mapM (isDirectory . (path </>))
-                    [ "branches", "hooks", "info"
+                    [ "hooks", "info"
                     , "logs", "objects", "refs"
                     , "refs"</> "heads", "refs"</> "tags"]
     return $ and ([dir] ++ subDirs)


### PR DESCRIPTION
Some `git` versions are not creating `.git/branches` directory, i.e. `1.9.2`. Also, git documentation says that this directory is kinda deprecated http://jk.gs/gitrepository-layout.html
