### PR TITLE
Replaced unix package with unix-compat to allow building on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist
 *.o
 *.hi
 Hit
+.cabal-sandbox
+cabal.sandbox.config

--- a/Data/Git/Storage/CacheFile.hs
+++ b/Data/Git/Storage/CacheFile.hs
@@ -14,8 +14,8 @@ import qualified Control.Exception as E
 import Filesystem.Path
 import Filesystem.Path.CurrentOS (encodeString)
 import Prelude hiding (FilePath)
-import System.Posix.Files (getFileStatus, modificationTime)
-import System.Posix.Types (EpochTime)
+import System.PosixCompat.Files (getFileStatus, modificationTime)
+import System.PosixCompat.Types (EpochTime)
 
 data CacheFile a = CacheFile
     { cacheFilepath :: FilePath

--- a/hit.cabal
+++ b/hit.cabal
@@ -48,7 +48,7 @@ Library
                    , zlib
                    , zlib-bindings >= 0.1 && < 0.2
                    , hourglass >= 0.2
-                   , unix
+                   , unix-compat
                    , utf8-string
                    , patience
   Exposed-modules:   Data.Git


### PR DESCRIPTION
Together with https://github.com/vincenthz/hs-hourglass/issues/6 it should allow for building hit on Windows.
