### PR TITLE
Add 'gitTimeToUTC'.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2010-2014 Vincent Hanquez <vincent@snarc.org>
+Copyright (c) 2015 Nikita Karetnikov <nikita@karetnikov.org>
 
 All rights reserved.
 

--- a/hit.cabal
+++ b/hit.cabal
@@ -13,7 +13,7 @@ Description:
     .
 License:             BSD3
 License-file:        LICENSE
-Copyright:           Vincent Hanquez <vincent@snarc.org>
+Copyright:           Vincent Hanquez <vincent@snarc.org>, Nikita Karetnikov <nikita@karetnikov.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
 Maintainer:          Vincent Hanquez <vincent@snarc.org>
 Category:            Development
@@ -47,6 +47,7 @@ Library
                    , random
                    , zlib
                    , zlib-bindings >= 0.1 && < 0.2
+                   , time > 1.0
                    , hourglass >= 0.2
                    , unix-compat
                    , utf8-string


### PR DESCRIPTION
This function makes it possible to use hit with the time library.  It
is similar to the 'toUTCTime' function, which was removed in
hit-0.6.0.