### PR TITLE
Semigroup instance for Tree to fix GHC 8.4 compatibility

### DIFF
--- a/Data/Git/Types.hs
+++ b/Data/Git/Types.hs
@@ -48,13 +48,14 @@ import qualified Data.ByteString.Lazy as L
 
 import Data.Git.Ref
 import Data.Git.Delta
-import Data.Git.Imports
+import Data.Git.Imports hiding ((<>))
 import Data.Hourglass (Elapsed, TimezoneOffset(..)
                       , timePrint, timeConvert
                       , Time(..), Timeable(..)
                       , LocalTime, localTimeSetTimezone, localTimeFromGlobal)
 import Data.Data
 import qualified Data.ByteString.UTF8 as UTF8
+import Data.Semigroup
 
 -- | type of a git object.
 data ObjectType =
@@ -185,10 +186,13 @@ data Person = Person
 -- | Represent a root tree with zero to many tree entries.
 data Tree = Tree { treeGetEnts :: [TreeEnt] } deriving (Show,Eq)
 
+instance Semigroup Tree where
+    Tree e1 <> Tree e2 = Tree (e1 ++ e2)
+
 instance Monoid Tree where
-    mempty                      = Tree []
-    mappend (Tree e1) (Tree e2) = Tree (e1 ++ e2)
-    mconcat trees               = Tree $ concatMap treeGetEnts trees
+    mempty        = Tree []
+    mappend       = (<>)
+    mconcat trees = Tree $ concatMap treeGetEnts trees
 
 -- | Represent a binary blob.
 data Blob = Blob { blobGetContent :: L.ByteString } deriving (Show,Eq)


### PR DESCRIPTION
Nothing too major -- just added the `Semigroup` instance that GHC 8.4 and base-4.11 complain about :)

Note that, for compatibility with other base versions, a redundant import is added which may trigger redundant import warnings when compiling.  Not sure how much of a priority it is for this library, but I can definitely look into seeing how to get rid of those with CPP or compatibility libs.

Thanks for the library and the great work!